### PR TITLE
Edit pass

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -118,7 +118,7 @@ This is particularly needed as even pandas `DataFrames` have no canonical persis
 
 ![**AnnData provides broad interoperability with tools and platforms.**
 `AnnData` objects can be created from a number of formats, including common delimited text files, or domain-specific formats like `loom` files or `CellRanger` outputs.
-Once in memory, AnnData provides an API for handling annotated matrices, proving a common base object used by the Python APIs of a range of analytic computational biology tools and integrating well with the APIs of the established Python machine learning ecosystem.
+Once in memory, AnnData provides an API for handling annotated matrices, proving a common base object used by a range of analytic computational biology tools and integrating well with the APIs of the established Python machine learning ecosystem.
 The in memory format has a one-to-one relationship with its hierarchical on disk formats (mapping of elements indicated by color) and uses language-independent technologies, enabling the use by non-Python applications and interchange with other ecosystems.
 \label{fig:ecosystem}
 ](figures/ecosystem.pdf)

--- a/paper.md
+++ b/paper.md
@@ -104,7 +104,8 @@ Subsetting the `AnnData` object by observations produces a memory-efficient view
 Due to the increasing scale of data, emphasis has been placed on providing efficient data handling operations with low memory and runtime overhead.
 To this end, AnnData offers sparse data support, out of core conversions between dense and sparse data, lazy subsetting ("views"), per-element operations for low total memory usage, in-place subsetting, combining AnnData objects with various merge strategies, lazy concatentation, batching, and a backed out-of-memory mode.
 
-In particular, `AnnData` takes great pains to support efficient operations with sparse data. While there currently is no equivalent API for working with sparse and dense data in the python ecosystem, `AnnData` abstracts over the differing existing APIs making it much easier for novices to handle each.
+In particular, `AnnData` takes great pains to support efficient operations with sparse data.
+While there is no production ready API for working with sparse and dense data in the python ecosystem, `AnnData` abstracts over the differing existing APIs making it much easier for novices to handle each.
 This concerns handling data both on-disk and in-memory with operations for out-of-core access.
 A noteworthy design choice means is that we do not follow columnar (or "variable major") data storage as for tidy-data and `DataFrames`.
 Our access patterns to X are typically row based, so we use CSR and C order arrays (or "observation major"), which allows efficiently accessing batches of the dataset, to meet the needs of batched learning algorithms.

--- a/paper.md
+++ b/paper.md
@@ -107,9 +107,8 @@ To this end, AnnData offers sparse data support, out of core conversions between
 In particular, `AnnData` takes great pains to support efficient operations with sparse data.
 While there is no production ready API for working with sparse and dense data in the python ecosystem, `AnnData` abstracts over the differing existing APIs making it much easier for novices to handle each.
 This concerns handling data both on-disk and in-memory with operations for out-of-core access.
-A noteworthy design choice means is that we do not follow columnar (or "variable major") data storage as for tidy-data and `DataFrames`.
-Our access patterns to X are typically row based, so we use CSR and C order arrays (or "observation major"), which allows efficiently accessing batches of the dataset, to meet the needs of batched learning algorithms.
-
+When access patterns are expected to be observation (or row) based as in batched learning algorithms, the user can store data matrices as CSR sparse matrices or C-order dense matrices.
+For access along variables – to visualize gene expression across a dataset – CSC sparse and fortran order dense matrices allow fast access along columns.
 
 ## The on-disk representation
 


### PR DESCRIPTION
Minor fixes

## Fixes #18 "means is"

Also, not sure I agreed with those statements in general. We do allow fast access to columns of X, but also I think "columnar" in terms of dataframes is distinct from "column-major" in terms of arrays. Either way:

* our on-disk storage for dataframes is columnar
* we do allow column-major and CSC matrices

I think we're not very hugely opinionated here, though we often default to row major (as does numpy).

## pydata/sparse exists

Reworded

> there currently is no equivalent API

Since there is, I just don't think it's production ready yet. Could use better wording.

"Since the standard APIs for dense and sparse arrays differ"?